### PR TITLE
Fix: fix old name

### DIFF
--- a/addons/script_panel_plus/configs/config.cfg
+++ b/addons/script_panel_plus/configs/config.cfg
@@ -43,12 +43,10 @@ show_search_line=true
 show_errors=true
 show_line_num=true
 show_script_title=true
-
 show_scripts_tab=true
 show_docs_tab=true
 show_files_tab=true
 show_favourites_tab=true
-
 show_script_save_indicator=true
 show_script_error_indicator=true
 show_script_lock_indicator=true

--- a/addons/script_panel_plus/plugin.cfg
+++ b/addons/script_panel_plus/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
-name="Advanced Script Panel"
-description=""
+name="Script Panel Plus"
+description="Script Panel Plus is a replacement plugin for a built-in Godot's scripting panel. It has more features and makes script-organizing a better experience."
 author="Loregret"
 version="1.1.4"
 script="plugin.gd"

--- a/addons/script_panel_plus/plugin.gd
+++ b/addons/script_panel_plus/plugin.gd
@@ -2,9 +2,9 @@
 extends EditorPlugin
 
 const project_settings_category := "script_panel_plus/panel_settings/"
-const config_path := "res://addons/advanced_script_panel/configs/config.cfg"
-const defaults_path := "res://addons/advanced_script_panel/configs/defaults.cfg"
-const scene := preload("res://addons/advanced_script_panel/script_panel/script_panel.tscn")
+const config_path := "res://addons/script_panel_plus/configs/config.cfg"
+const defaults_path := "res://addons/script_panel_plus/configs/defaults.cfg"
+const scene := preload("res://addons/script_panel_plus/script_panel/script_panel.tscn")
 
 var config: ConfigFile
 var defaults: ConfigFile

--- a/addons/script_panel_plus/script_panel/script_panel.gd
+++ b/addons/script_panel_plus/script_panel/script_panel.gd
@@ -25,7 +25,7 @@ var show_button: BaseButton
 
 var save_data := {}
 var load_data := {}
-const save_path := "res://addons/advanced_script_panel/saves/save.dat"
+const save_path := "res://addons/script_panel_plus/saves/save.dat"
 
 ## Script Arrays
 var all:     Array[ScriptItem] = []

--- a/addons/script_panel_plus/script_panel/script_panel.tscn
+++ b/addons/script_panel_plus/script_panel/script_panel.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=9 format=3 uid="uid://ln8u12ni037b"]
 
-[ext_resource type="Script" path="res://addons/advanced_script_panel/script_panel/script_panel.gd" id="1_b1kur"]
-[ext_resource type="Script" path="res://addons/advanced_script_panel/script_panel/script_list.gd" id="2_g67jx"]
+[ext_resource type="Script" path="res://addons/script_panel_plus/script_panel/script_panel.gd" id="1_b1kur"]
+[ext_resource type="Script" path="res://addons/script_panel_plus/script_panel/script_list.gd" id="2_g67jx"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_06sl4"]
 

--- a/project.godot
+++ b/project.godot
@@ -11,10 +11,10 @@ config_version=5
 [application]
 
 config/name="Advanced Script Panel"
-run/main_scene="res://addons/advanced_script_panel/script_panel/script_panel.tscn"
+run/main_scene="res://addons/script_panel_plus/script_panel/script_panel.tscn"
 config/features=PackedStringArray("4.0", "GL Compatibility")
 boot_splash/show_image=false
-config/icon="res://addons/advanced_script_panel/assets/icon.svg"
+config/icon="res://addons/script_panel_plus/assets/icon.svg"
 
 [filesystem]
 

--- a/project.godot
+++ b/project.godot
@@ -10,11 +10,15 @@ config_version=5
 
 [application]
 
-config/name="Advanced Script Panel"
+config/name="Script Panel Plus"
 run/main_scene="res://addons/script_panel_plus/script_panel/script_panel.tscn"
 config/features=PackedStringArray("4.0", "GL Compatibility")
 boot_splash/show_image=false
-config/icon="res://addons/script_panel_plus/assets/icon.svg"
+config/icon="res://addons/script_panel_plus/assets/icons/icon.svg"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/script_panel_plus/plugin.cfg")
 
 [filesystem]
 


### PR DESCRIPTION
The previous name was "advanced_script_panel" and after rename the plugin wasn't working. This should fix it.